### PR TITLE
Skip empty backup option

### DIFF
--- a/BackupUsage.md
+++ b/BackupUsage.md
@@ -5,7 +5,7 @@ This command is used to create new incremental backups.
 ## Usage
 
 ```
-python3 -m incremental_backup backup <source_dir> <target_dir> [--exclude <exclude_pattern1> [<exclude_pattern2> ...]]
+python3 -m incremental_backup backup <source_dir> <target_dir> [--exclude <exclude_pattern1> [<exclude_pattern2> ...]] [--skip-empty]
 ```
 
 `<source_dir>` - The path of the directory to be backed up.
@@ -15,6 +15,9 @@ It's highly recommended that `<target_dir>` is not contained within `<source_dir
 
 `<exclude_pattern>` - Regular expressions to match paths in the source directory that will be excluded from the backup.
 Please see the _Path Exclude Patterns_ section for details.
+
+`--skip-empty` - If specified, a backup is only created if some files changed.
+Useful to avoid accumulating a large amount of empty backups, which may improve the performance of the tool.
 
 ## Theory of Operation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Private entities begin with a single underscore (e.g. modules, functions, class 
 
 TODO: update when making changes.
 
+## 1.2.0 - 2024/04/10
+
+Flag to skip creation of backups which record no changes.
+
 ## 1.1.0 - 2024/04/04
 
 Prune command for deleting unnecessary backups.

--- a/incremental_backup/backup/backup.py
+++ b/incremental_backup/backup/backup.py
@@ -96,8 +96,8 @@ def perform_backup(source_directory: StrPath, target_directory: StrPath, exclude
         :param target_directory: Directory to create the new backup in, and where any previous backups are read from.
             Need not exist.
         :param exclude_patterns: Patterns to match paths which will be excluded from the backup.
-        :param skip_empty: Only perform the backup if there are file changes to record.
         :param callbacks: Callbacks for certain events during execution. See `BackupCallbacks`.
+        :param skip_empty: Only perform the backup if there are file changes to record.
         :return: Metadata and summary information for the backup operation. None if the backup was skipped.
         :except BackupError: If an error occurs that prevents the backup operation from creating a valid backup. See
             `BackupError`.

--- a/incremental_backup/backup/backup.py
+++ b/incremental_backup/backup/backup.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import Callable, Iterable, Optional, Sequence
 
 from incremental_backup.backup.filesystem import scan_filesystem, ScanFilesystemCallbacks
-from incremental_backup.backup.plan import BackupPlan, execute_backup_plan, ExecuteBackupPlanCallbacks
+from incremental_backup.backup.plan import BackupPlan, execute_backup_plan, ExecuteBackupPlanCallbacks, \
+    ExecuteBackupPlanResults
 from incremental_backup.backup.sum import BackupSum
 from incremental_backup.meta import BackupCompleteInfo, BackupDirectoryCreationError, BackupManifest, \
     BackupMetadata, BackupStartInfo, COMPLETE_INFO_FILENAME, create_new_backup_directory, \
@@ -75,8 +76,9 @@ class BackupCallbacks:
         First argument is the path to the file, second argument is the raised exception."""
 
 
+# TODO: improve the arguments. Maybe have an "options" object argument
 def perform_backup(source_directory: StrPath, target_directory: StrPath, exclude_patterns: Iterable[PathExcludePattern],
-                   callbacks: BackupCallbacks = BackupCallbacks()) -> BackupResults:
+                   callbacks: BackupCallbacks = BackupCallbacks(), skip_empty: bool = False) -> Optional[BackupResults]:
     """Performs the entire operation of creating a new backup, including creating the backup directory, copying files,
         and saving metadata.
 
@@ -84,28 +86,31 @@ def perform_backup(source_directory: StrPath, target_directory: StrPath, exclude
         :param target_directory: Directory to create the new backup in, and where any previous backups are read from.
             Need not exist.
         :param exclude_patterns: Patterns to match paths which will be excluded from the backup.
+        :param skip_empty: Only perform the backup if there are file changes to record.
         :param callbacks: Callbacks for certain events during execution. See `BackupCallbacks`.
-        :return: Metadata and summary information for the backup operation.
+        :return: Metadata and summary information for the backup operation. None if the backup was skipped.
         :except BackupError: If an error occurs that prevents the backup operation from creating a valid backup. See
             `BackupError`.
     """
 
-    return _BackupOperation(source_directory, target_directory, exclude_patterns, callbacks).perform_backup()
+    return _BackupOperation(source_directory, target_directory, exclude_patterns, skip_empty, callbacks).perform_backup()
 
 
 class _BackupOperation:
     """Implementation of the backup creation operation."""
 
     def __init__(self, source_directory: StrPath, target_directory: StrPath,
-                 exclude_patterns: Iterable[PathExcludePattern], callbacks: BackupCallbacks = BackupCallbacks()) -> None:
+                 exclude_patterns: Iterable[PathExcludePattern], skip_empty: bool,
+                 callbacks: BackupCallbacks = BackupCallbacks()) -> None:
         self.source_directory = Path(source_directory)
         self.target_directory = Path(target_directory)
         self.exclude_patterns = tuple(exclude_patterns)
+        self.skip_empty = skip_empty
         self.callbacks = callbacks
 
         self._init_working_state()
 
-    def perform_backup(self) -> BackupResults:
+    def perform_backup(self) -> Optional[BackupResults]:
         """Creates a new backup.
 
             :except BackupError: If an error occurs that prevents the backup operation from creating a valid backup. See
@@ -120,37 +125,37 @@ class _BackupOperation:
         previous_backups = self._read_previous_backups()
         backup_sum = BackupSum.from_backups(previous_backups)
 
-        (self.callbacks.on_before_initialise_backup)()
-        self._create_backup_directory()
-        assert self.backup_path is not None
-        data_path = self._create_data_directory(self.backup_path)
-        self._create_start_info()
+        self.callbacks.on_before_initialise_backup()
+        start_time = datetime.now(timezone.utc)
+        if not self.skip_empty:
+            backup_path = self._create_backup_directory()
+            data_path = self._create_data_directory(backup_path)
+            start_info = self._create_and_write_start_info(backup_path, start_time)
 
         backup_plan = self._compute_backup_plan(backup_sum)
-        self._back_up_files(data_path, backup_plan)
+        if self._is_backup_plan_empty(backup_plan):
+            return None
 
-        (self.callbacks.on_before_save_metadata)()
-        self._save_manifest()
-        self._save_complete_info()
+        if self.skip_empty:
+            backup_path = self._create_backup_directory()
+            data_path = self._create_data_directory(backup_path)
+            start_info = self._create_and_write_start_info(backup_path, start_time)
 
-        assert self.start_info is not None
-        assert self.manifest is not None
-        assert self.complete_info is not None
-        assert self.files_copied is not None
-        assert self.files_removed is not None
+        execute_results = self._back_up_files(data_path, backup_plan)
+        complete_info = self._create_complete_info()
+
+        self.callbacks.on_before_save_metadata()
+        self._save_manifest(backup_path, execute_results.manifest)
+        self._save_complete_info(backup_path, complete_info)
+
         return BackupResults(
-            self.backup_path, self.start_info, self.manifest, self.complete_info, self.files_copied, self.files_removed)
+            backup_path, start_info, execute_results.manifest, complete_info, execute_results.files_copied,
+            execute_results.files_removed)
 
     def _init_working_state(self) -> None:
         """Initialises various shared data used by and operated on by the methods in this class."""
 
-        self.backup_path: Optional[Path] = None
-        self.start_info: Optional[BackupStartInfo] = None
-        self.manifest: Optional[BackupManifest] = None
-        self.complete_info: Optional[BackupCompleteInfo] = None
-        self.paths_skipped: Optional[bool] = None
-        self.files_copied: Optional[int] = None
-        self.files_removed: Optional[int] = None
+        self.paths_skipped = False
 
     def _validate_source_directory(self) -> None:
         """Validates the backup source directory.
@@ -188,7 +193,7 @@ class _BackupOperation:
             :except BackupError: If the target directory cannot be enumerated.
         """
 
-        (self.callbacks.on_before_read_previous_backups)()
+        self.callbacks.on_before_read_previous_backups()
 
         try:
             if not self.target_directory.exists():
@@ -199,11 +204,17 @@ class _BackupOperation:
             raise BackupError(f'Failed to enumerate target directory: {e}') from e
         backups = tuple(backups)
 
-        (self.callbacks.on_after_read_previous_backups)(backups)
+        self.callbacks.on_after_read_previous_backups(backups)
 
         return backups
 
-    def _create_backup_directory(self) -> None:
+    @staticmethod
+    def _is_backup_plan_empty(backup_plan: BackupPlan) -> bool:
+        root = backup_plan.root
+        return not (root.copied_files or root.removed_files or root.removed_directories or root.subdirectories
+            or root.contains_copied_files or root.contains_removed_items or root.removed_directory_file_count)
+
+    def _create_backup_directory(self) -> Path:
         """Creates a new backup directory within the target directory.
 
             :except BackupError: If the directory could not be created.
@@ -215,9 +226,10 @@ class _BackupOperation:
             raise BackupError(str(e)) from e
 
         backup_path = self.target_directory / backup_name
-        self.backup_path = backup_path
 
-        (self.callbacks.on_created_backup_directory)(backup_path)
+        self.callbacks.on_created_backup_directory(backup_path)
+
+        return backup_path
 
     @staticmethod
     def _create_data_directory(backup_path: Path, /) -> Path:
@@ -234,73 +246,71 @@ class _BackupOperation:
             raise BackupError(f'Failed to create backup data directory: {e}') from e
         return path
 
-    def _create_start_info(self) -> None:
+    @staticmethod
+    def _create_and_write_start_info(backup_path: Path, start_time: datetime) -> BackupStartInfo:
         """Creates and writes the backup start information to file within the backup directory.
 
             :except BackupError: If the file could not be written to.
         """
 
-        start_info = BackupStartInfo(datetime.now(timezone.utc))
-        self.start_info = start_info
-        assert self.backup_path is not None
-        file_path = self.backup_path / START_INFO_FILENAME
+        start_info = BackupStartInfo(start_time)
+        file_path = backup_path / START_INFO_FILENAME
         try:
             write_backup_start_info_file(file_path, start_info)
         except OSError as e:
             raise BackupError(f'Failed to write backup start information file: {e}') from e
+        return start_info
 
     def _compute_backup_plan(self, backup_sum: BackupSum) -> BackupPlan:
         """Scans the source directory and generates the backup plan."""
 
-        (self.callbacks.on_before_scan_source)()
+        self.callbacks.on_before_scan_source()
 
         scan_results = scan_filesystem(self.source_directory, self.exclude_patterns, self.callbacks.scan_source)
         self.paths_skipped = self.paths_skipped or scan_results.paths_skipped
         backup_plan = BackupPlan.new(scan_results.tree, backup_sum)
         return backup_plan
 
-    def _back_up_files(self, destination_path: StrPath, backup_plan: BackupPlan) -> None:
+    def _back_up_files(self, destination_path: StrPath, backup_plan: BackupPlan) -> ExecuteBackupPlanResults:
         """Backs up files from the source directory to the backup directory according to the backup plan."""
 
-        (self.callbacks.on_before_copy_files)()
+        self.callbacks.on_before_copy_files()
 
         execute_results = execute_backup_plan(
             backup_plan, self.source_directory, destination_path, self.callbacks.execute_plan)
 
         self.paths_skipped = self.paths_skipped or execute_results.paths_skipped
-        self.manifest = execute_results.manifest
-        self.complete_info = BackupCompleteInfo(datetime.now(timezone.utc), self.paths_skipped)
-        self.files_copied = execute_results.files_copied
-        self.files_removed = execute_results.files_removed
 
-    def _save_manifest(self) -> None:
+        return execute_results
+
+    def _create_complete_info(self) -> BackupCompleteInfo:
+        return BackupCompleteInfo(datetime.now(timezone.utc), self.paths_skipped)
+
+    @staticmethod
+    def _save_manifest(backup_path: Path, manifest: BackupManifest) -> None:
         """Writes the backup manifest to file within the backup directory.
 
             :except BackupError: If the file could not be written to.
         """
 
-        assert self.backup_path is not None
-        file_path = self.backup_path / MANIFEST_FILENAME
+        file_path = backup_path / MANIFEST_FILENAME
         try:
-            assert self.manifest is not None
-            write_backup_manifest_file(file_path, self.manifest)
+            write_backup_manifest_file(file_path, manifest)
         except OSError as e:
             raise BackupError(f'Failed to write backup manifest file: {e}') from e
 
-    def _save_complete_info(self) -> None:
+    def _save_complete_info(self, backup_path: Path, complete_info: BackupCompleteInfo) -> None:
         """Writes the backup completion information to file within the backup directory.
 
             It is not a fatal error if this operation fails, since the completion information is not required by the
             application at this time."""
 
-        assert self.backup_path is not None
-        file_path = self.backup_path / COMPLETE_INFO_FILENAME
+        file_path = backup_path / COMPLETE_INFO_FILENAME
         try:
-            assert self.complete_info is not None
-            write_backup_complete_info_file(file_path, self.complete_info)
+            write_backup_complete_info_file(file_path, complete_info)
         except OSError as e:
             # Not fatal since the completion info isn't currently used by the software.
-            (self.callbacks.on_write_complete_info_error)(file_path, e)
+            self.callbacks.on_write_complete_info_error(file_path, e)
 
 
 class BackupError(Exception):

--- a/incremental_backup/cli/command/backup.py
+++ b/incremental_backup/cli/command/backup.py
@@ -32,7 +32,7 @@ class BackupCommand(Command):
         parser.add_argument(
             '--exclude', nargs='+', type=PathExcludePattern, required=False, help='Path patterns to exclude.')
         parser.add_argument('--skip-empty', action='store_true', default=False,
-            help='Only create a backup if there are file changes.')
+            help='Only back up if there are file changes to record.')
 
     def __init__(self, arguments: argparse.Namespace, /) -> None:
         """
@@ -106,6 +106,8 @@ class BackupCommand(Command):
                 print(f'  {pattern}')
         else:
             print('  <none>')
+        if self.skip_empty:
+            print('Skip empty backup: yes')
         print()
 
     @staticmethod
@@ -115,3 +117,5 @@ class BackupCommand(Command):
         files_copied = results.files_copied if results else 0
         files_removed = results.files_removed if results else 0
         print(f'+{files_copied} / -{files_removed} files')
+        if results is None:
+            print('Skipping empty backup')

--- a/incremental_backup/cli/command/backup.py
+++ b/incremental_backup/cli/command/backup.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-from typing import Sequence
+from typing import Optional, Sequence
 
 from incremental_backup.backup import BackupCallbacks, BackupError, BackupResults, ExecuteBackupPlanCallbacks, \
     perform_backup, ScanFilesystemCallbacks
@@ -31,6 +31,8 @@ class BackupCommand(Command):
         parser.add_argument('target_dir', type=Path, help='Directory to back up into.')
         parser.add_argument(
             '--exclude', nargs='+', type=PathExcludePattern, required=False, help='Path patterns to exclude.')
+        parser.add_argument('--skip-empty', action='store_true', default=False,
+            help='Only create a backup if there are file changes.')
 
     def __init__(self, arguments: argparse.Namespace, /) -> None:
         """
@@ -41,6 +43,7 @@ class BackupCommand(Command):
         self.source_path: Path = arguments.source_dir
         self.target_path: Path = arguments.target_dir
         self.exclude_patterns: Sequence[PathExcludePattern] = arguments.exclude or ()
+        self.skip_empty: bool = arguments.skip_empty
 
     def run(self) -> None:
         """Executes the backup command.
@@ -53,7 +56,8 @@ class BackupCommand(Command):
         callbacks = self._backup_callbacks()
 
         try:
-            results = perform_backup(self.source_path, self.target_path, self.exclude_patterns, callbacks)
+            results = perform_backup(
+                self.source_path, self.target_path, self.exclude_patterns, callbacks, self.skip_empty)
         except BackupError as e:
             raise CommandRuntimeError(str(e)) from e
 
@@ -105,7 +109,9 @@ class BackupCommand(Command):
         print()
 
     @staticmethod
-    def _print_results(results: BackupResults, /) -> None:
+    def _print_results(results: Optional[BackupResults], /) -> None:
         """Prints backup results to the console."""
 
-        print(f'+{results.files_copied} / -{results.files_removed} files')
+        files_copied = results.files_copied if results else 0
+        files_removed = results.files_removed if results else 0
+        print(f'+{files_copied} / -{files_removed} files')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "incremental_backup"
 # TODO: update when making changes.
-version = "1.1.0"
+version = "1.2.0"
 authors = [
     { name="Reece Jones", email="reece.jones131@gmail.com" }
 ]

--- a/test/test_backup/test_backup.py
+++ b/test/test_backup/test_backup.py
@@ -714,4 +714,7 @@ def test_perform_backup_some_invalid_backups(tmpdir: Path) -> None:
     assert actual_manifest_str == expected_manifest_str
 
 
+# TODO: test skip_empty
+
+
 METADATA_TIME_TOLERANCE = 5     # Seconds

--- a/test/test_backup/test_backup.py
+++ b/test/test_backup/test_backup.py
@@ -15,6 +15,9 @@ from incremental_backup.path_exclude import PathExcludePattern
 from helpers import AssertFilesystemUnmodified, dir_entries, unordered_equal, write_file_with_mtime
 
 
+# TODO: clean up tests, this is quite messy. should abstract more and have more predictable file names.
+
+
 def test_perform_backup_nonexistent_source(tmpdir: Path) -> None:
     source_path = tmpdir / 'source'
 
@@ -714,7 +717,54 @@ def test_perform_backup_some_invalid_backups(tmpdir: Path) -> None:
     assert actual_manifest_str == expected_manifest_str
 
 
-# TODO: test skip_empty
+def test_perform_backup_skip_empty(tmpdir: Path) -> None:
+    # Target directory exists but is empty.
+
+    source_path = tmpdir / 'source'
+    source_path.mkdir()
+
+    target_path = tmpdir / 'target'
+    target_path.mkdir()
+
+    actual_callbacks: list[Any] = []
+
+    callbacks = BackupCallbacks(
+        on_before_read_previous_backups=lambda: actual_callbacks.append('before_read_previous_backups'),
+        read_backups=ReadBackupsCallbacks(
+            on_query_entry_error=lambda path, error: pytest.fail(f'Unexpected on_query_entry_error: {path=} {error=}'),
+            on_read_metadata_error=lambda path, error:
+                pytest.fail(f'Unexpected on_read_metadata_error: {path=} {error=}')
+        ),
+        on_after_read_previous_backups=lambda backups:
+            actual_callbacks.append(('after_read_previous_backups', backups)),
+        on_before_initialise_backup=lambda: actual_callbacks.append('before_initialise_backup'),
+        on_created_backup_directory=lambda path: actual_callbacks.append(('created_backup_directory', path)),
+        on_before_scan_source=lambda: actual_callbacks.append('before_scan_source'),
+        scan_source=ScanFilesystemCallbacks(
+            on_exclude=lambda path: pytest.fail(f'Unexpected on_exclude: {path=}'),
+            on_listdir_error=lambda path, error: pytest.fail(f'Unexpected on_listdir_error: {path=} {error=}'),
+            on_metadata_error=lambda path, error: pytest.fail(f'Unexpected on_metadata_error: {path=} {error=}')
+        ),
+        on_before_copy_files=lambda: actual_callbacks.append('before_copy_files'),
+        execute_plan=ExecuteBackupPlanCallbacks(
+            on_mkdir_error=lambda path, error: pytest.fail(f'Unexpected on_mkdir_error: {path=} {error=}'),
+            on_copy_error=lambda src, dest, error: pytest.fail(f'Unexpected on_copy_error: {src=} {dest=} {error}=')
+        ),
+        on_before_save_metadata=lambda: actual_callbacks.append('before_save_metadata'),
+        on_write_complete_info_error=lambda path, error:
+            pytest.fail(f'Unexpected on_write_complete_info_error: {path=} {error=}')
+    )
+
+    with AssertFilesystemUnmodified(tmpdir):
+        results = perform_backup(source_path, target_path, (), callbacks, skip_empty=True)
+
+    assert results is None
+
+    assert actual_callbacks == [
+        'before_read_previous_backups',
+        ('after_read_previous_backups', ()),
+        'before_scan_source'
+    ]
 
 
 METADATA_TIME_TOLERANCE = 5     # Seconds

--- a/test/test_backup/test_backup.py
+++ b/test/test_backup/test_backup.py
@@ -718,7 +718,7 @@ def test_perform_backup_some_invalid_backups(tmpdir: Path) -> None:
 
 
 def test_perform_backup_skip_empty(tmpdir: Path) -> None:
-    # Target directory exists but is empty.
+    # skip_empty option is specified and there are no changes to record.
 
     source_path = tmpdir / 'source'
     source_path.mkdir()


### PR DESCRIPTION
Command line flag to allow skipping creation of backups which record no changes. This is useful to avoid creating a large amount of empty backups which contribute nothing and slow future backup operations.